### PR TITLE
Implement lazy-loading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,42 @@ A lightweight, highly configurable carousel for Vue 3. (EVENTUALLY).
 
 > ⚠️ This is a completely new work in progress and by no means production-ready.
 
+## Usage
+
+### Configuration
+
+#### Basic
+
+| Property   | Type     | Default | Description                                                                    |
+|------------|----------|---------|--------------------------------------------------------------------------------|
+| `slides`   | `Array`  | `[]`    | The items to be displayed in the carousel.                                     |
+ | `maxWidth` | `String` | `350px` | The maximum width of any given carousel slide. Takes any CSS-compatible value. |
+| `minWidth` | `String` | `100px` | The minimum width of any given carousel slide. Takes any CSS-compatible value. |
+| `lazyload` | `Object` | `{}`    | Configuration for lazy loading images (see below).                             |
+
+#### Lazyload
+bangoround.js supports lazy loading of slides. This is done by setting the `lazyload` property to an object with the following properties:
+      
+  ```javascript
+  {
+  enabled: true,
+  threshold: 0,
+  rootMargin: '0px'
+  }
+   ```
+These are the same options as the native `IntersectionObserver` API. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) for more information.
+
+| Property           | Type      | Default | Description                                                                                                  |
+|--------------------|-----------|---------|--------------------------------------------------------------------------------------------------------------|
+| `enabled`          | `Boolean` | `false` | Whether or not to enable lazy loading.                                                                       |
+| `threshold`        | `Number`  | `0`     | The distance from the viewport at which to start loading the slide.                                          |
+| `rootMargin`       | `String`  | `0px`   | The margin around the viewport in which to start loading the slide.                                          |
+ | `persistAfterLoad` | `Boolean` | `false` | If set to `true`, bangoround.js will not unload the element once it has been loaded, even if it leaves view. |
+
+
+### Slots
+
+
 ## Project setup
 ```
 npm install

--- a/lib/BangoRound.vue
+++ b/lib/BangoRound.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup lang="ts">
-import {ref, computed, onMounted, defineProps, defineExpose, reactive, watchEffect} from 'vue';
+import {ref, computed, onMounted, defineProps, defineExpose, reactive} from 'vue';
 import useResize from './composables/useResize';
 import {useLazyLoad} from './composables/useLazyload';
 import {UseLazyLoadOptions} from './composables/useLazyload';

--- a/lib/composables/useLazyload.ts
+++ b/lib/composables/useLazyload.ts
@@ -1,0 +1,52 @@
+// useLazyLoad.ts
+import { Ref, onUnmounted, ref } from 'vue';
+
+interface UseLazyLoadOptions {
+    root?: Element | null;
+    rootMargin?: string;
+    threshold?: number | number[];
+    onVisible?: () => void; // Callback when the element becomes visible
+    onExit?: () => void; // Callback when the element exits the viewport
+    persistAfterLoad?: boolean; // Prevents the slide being removed from the observer after it's visible, even if it leaves view.
+}
+
+export function useLazyLoad(target: Ref<Element | null>, options: UseLazyLoadOptions) {
+    const isVisible = ref(false);
+
+    const observer = new IntersectionObserver(
+        (entries) => {
+            entries.forEach((entry) => {
+                // Update visibility state
+                isVisible.value = entry.isIntersecting;
+                // Call the callback if the target is visible
+                if (entry.isIntersecting) {
+                    options.onVisible?.();
+                    if (options.persistAfterLoad) {
+                        observer.unobserve(entry.target);
+                    }
+                } else {
+                    options.onExit?.();
+                }
+            });
+        },
+        {
+            root: options.root || null,
+            rootMargin: options.rootMargin || '0px',
+            threshold: options.threshold || 0.1,
+        }
+    );
+
+    if (target.value) {
+        observer.observe(target.value);
+    }
+
+    onUnmounted(() => {
+        if (target.value) {
+            observer.disconnect();
+        }
+    });
+
+    return { isVisible };
+}
+
+export type { UseLazyLoadOptions };

--- a/lib/composables/useLazyload.ts
+++ b/lib/composables/useLazyload.ts
@@ -1,4 +1,3 @@
-// useLazyLoad.ts
 import { Ref, onUnmounted, ref } from 'vue';
 
 interface UseLazyLoadOptions {


### PR DESCRIPTION
This commit implements lazy loading as an optional behaviour. We leverage IntersectionObserver to dynamically load and unload slide elements as they enter and exit the parent carousel container. Usage details and config options are now present in the README.